### PR TITLE
 TrustedProxy Middleware to Skeleton Application

### DIFF
--- a/middleware/trustedProxy.go
+++ b/middleware/trustedProxy.go
@@ -1,0 +1,168 @@
+package middleware
+
+import (
+	"crypto/tls"
+	"net"
+	"net/http"
+	"os"
+	"strings"
+)
+
+// TrustedProxy securely configures HTTP requests when behind a reverse proxy. How
+// do you safely trust forwarded headers without creating security vulnerabilities?
+//
+// When your Go app sits behind nginx, the original client information (IP, protocol,
+// host) gets lost because nginx becomes the direct client. Nginx forwards the real
+// client info via headers like X-Forwarded-Proto and X-Forwarded-Host, but blindly
+// trusting these headers is dangerous - any client could spoof them.
+//
+// Security Model:
+//   - Only trusts headers from explicitly configured proxy IPs
+//   - Validates source IP against trusted proxy list before processing headers
+//   - Provides granular control over which headers to trust
+//   - Safe by default (no headers trusted unless explicitly configured)
+//
+// Configuration via environment variables:
+//
+//	TRUSTED_PROXIES: Comma-separated list of trusted proxy IPs/CIDRs
+//	                Examples: "127.0.0.1,192.168.1.0/24" or "10.0.0.0/8"
+//	TRUST_PROXY_HEADERS: Comma-separated list of headers to trust
+//	                    Examples: "proto,host" or "proto,host,port,for"
+//
+// Security considerations:
+//   - Never set TRUSTED_PROXIES to "*" or "0.0.0.0/0" in production
+//   - Only include your actual reverse proxy IPs
+//   - Headers from untrusted IPs are completely ignored
+func (a *Middleware) TrustedProxy(next http.Handler) http.Handler {
+	// Parse trusted proxy configuration once at startup
+	trustedProxies := parseTrustedProxies(os.Getenv("TRUSTED_PROXIES"))
+	trustedHeaders := parseTrustedHeaders(os.Getenv("TRUST_PROXY_HEADERS"))
+
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+
+		// Extract client IP (could be from X-Real-IP or direct connection)
+		clientIP := getClientIP(r)
+
+		// Only process headers if request comes from a trusted proxy
+		if isTrustedProxy(clientIP, trustedProxies) {
+			// Process X-Forwarded-Proto if trusted
+			if contains(trustedHeaders, "proto") {
+				if proto := r.Header.Get("X-Forwarded-Proto"); proto == "https" {
+					r.URL.Scheme = "https"
+					r.TLS = &tls.ConnectionState{}
+				}
+			}
+
+			// Process X-Forwarded-Host if trusted
+			if contains(trustedHeaders, "host") {
+				if host := r.Header.Get("X-Forwarded-Host"); host != "" {
+					r.Host = host
+					r.URL.Host = host
+				}
+			}
+
+		}
+
+		// If not from trusted proxy, ignore all headers (secure default)
+		next.ServeHTTP(w, r)
+	})
+}
+
+// parseTrustedProxies converts environment string to list of trusted networks
+func parseTrustedProxies(proxyList string) []*net.IPNet {
+	if proxyList == "" {
+		return nil // No proxies trusted by default
+	}
+
+	var networks []*net.IPNet
+	proxies := strings.Split(proxyList, ",")
+
+	for _, proxy := range proxies {
+		proxy = strings.TrimSpace(proxy)
+		if proxy == "" {
+			continue
+		}
+
+		// Handle single IP (add /32 or /128)
+		if !strings.Contains(proxy, "/") {
+			if strings.Contains(proxy, ":") {
+				proxy += "/128" // IPv6
+			} else {
+				proxy += "/32" // IPv4
+			}
+		}
+
+		_, network, err := net.ParseCIDR(proxy)
+		if err == nil {
+			networks = append(networks, network)
+		}
+	}
+
+	return networks
+}
+
+// parseTrustedHeaders converts environment string to list of trusted headers
+func parseTrustedHeaders(headerList string) []string {
+	if headerList == "" {
+		return []string{"proto", "host"} // Safe defaults
+	}
+
+	headers := strings.Split(headerList, ",")
+	for i, header := range headers {
+		headers[i] = strings.TrimSpace(header)
+	}
+	return headers
+}
+
+// getClientIP extracts the real client IP, handling various proxy scenarios
+func getClientIP(r *http.Request) string {
+	// Try X-Real-IP first (most reliable from reverse proxy)
+	if ip := r.Header.Get("X-Real-IP"); ip != "" {
+		return ip
+	}
+
+	// Try X-Forwarded-For (could be comma-separated list)
+	if ip := r.Header.Get("X-Forwarded-For"); ip != "" {
+		// Take the first IP (original client)
+		if parts := strings.Split(ip, ","); len(parts) > 0 {
+			return strings.TrimSpace(parts[0])
+		}
+	}
+
+	// Fall back to direct connection IP
+	if ip, _, err := net.SplitHostPort(r.RemoteAddr); err == nil {
+		return ip
+	}
+
+	return r.RemoteAddr
+}
+
+// isTrustedProxy checks if the given IP is in the trusted proxy list
+func isTrustedProxy(ip string, trustedNetworks []*net.IPNet) bool {
+	if len(trustedNetworks) == 0 {
+		return false // No proxies trusted
+	}
+
+	clientIP := net.ParseIP(ip)
+	if clientIP == nil {
+		return false
+	}
+
+	for _, network := range trustedNetworks {
+		if network.Contains(clientIP) {
+			return true
+		}
+	}
+
+	return false
+}
+
+// contains checks if a string slice contains a specific string
+func contains(slice []string, item string) bool {
+	for _, s := range slice {
+		if s == item {
+			return true
+		}
+	}
+	return false
+}

--- a/middleware/trustedProxy_test.go
+++ b/middleware/trustedProxy_test.go
@@ -1,0 +1,362 @@
+package middleware
+
+import (
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"testing"
+)
+
+func TestTrustedProxy_TrustedIPWithHTTPS(t *testing.T) {
+	// Set environment variables
+	os.Setenv("TRUSTED_PROXIES", "127.0.0.1")
+	os.Setenv("TRUST_PROXY_HEADERS", "proto,host")
+	defer func() {
+		os.Unsetenv("TRUSTED_PROXIES")
+		os.Unsetenv("TRUST_PROXY_HEADERS")
+	}()
+
+	m := &Middleware{}
+	var capturedRequest *http.Request
+
+	handler := m.TrustedProxy(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		capturedRequest = r
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	req := httptest.NewRequest("GET", "http://localhost/test", nil)
+	req.RemoteAddr = "127.0.0.1:12345"
+	req.Header.Set("X-Forwarded-Proto", "https")
+	req.Header.Set("X-Forwarded-Host", "example.com")
+
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+
+	// Verify HTTPS was set
+	if capturedRequest.URL.Scheme != "https" {
+		t.Errorf("Expected scheme 'https', got '%s'", capturedRequest.URL.Scheme)
+	}
+
+	if capturedRequest.TLS == nil {
+		t.Error("Expected TLS to be set for HTTPS")
+	}
+
+	if capturedRequest.Host != "example.com" {
+		t.Errorf("Expected host 'example.com', got '%s'", capturedRequest.Host)
+	}
+}
+
+func TestTrustedProxy_UntrustedIPIgnored(t *testing.T) {
+	os.Setenv("TRUSTED_PROXIES", "127.0.0.1")
+	os.Setenv("TRUST_PROXY_HEADERS", "proto,host")
+	defer func() {
+		os.Unsetenv("TRUSTED_PROXIES")
+		os.Unsetenv("TRUST_PROXY_HEADERS")
+	}()
+
+	m := &Middleware{}
+	var capturedRequest *http.Request
+
+	handler := m.TrustedProxy(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		capturedRequest = r
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	req := httptest.NewRequest("GET", "http://localhost/test", nil)
+	req.RemoteAddr = "192.168.1.100:54321" // Untrusted IP
+	req.Header.Set("X-Forwarded-Proto", "https")
+	req.Header.Set("X-Forwarded-Host", "malicious.com")
+
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+
+	// Headers should be ignored
+	if capturedRequest.URL.Scheme == "https" {
+		t.Error("Expected scheme to not be set from untrusted proxy")
+	}
+
+	if capturedRequest.TLS != nil {
+		t.Error("Expected TLS to not be set from untrusted proxy")
+	}
+
+	if capturedRequest.Host == "malicious.com" {
+		t.Error("Expected host to not be set from untrusted proxy")
+	}
+}
+
+func TestTrustedProxy_CIDRRange(t *testing.T) {
+	os.Setenv("TRUSTED_PROXIES", "192.168.1.0/24")
+	os.Setenv("TRUST_PROXY_HEADERS", "proto")
+	defer func() {
+		os.Unsetenv("TRUSTED_PROXIES")
+		os.Unsetenv("TRUST_PROXY_HEADERS")
+	}()
+
+	m := &Middleware{}
+	var capturedRequest *http.Request
+
+	handler := m.TrustedProxy(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		capturedRequest = r
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	req := httptest.NewRequest("GET", "http://localhost/test", nil)
+	req.RemoteAddr = "192.168.1.50:12345" // Within CIDR range
+	req.Header.Set("X-Forwarded-Proto", "https")
+
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+
+	if capturedRequest.URL.Scheme != "https" {
+		t.Errorf("Expected scheme 'https' from trusted CIDR range, got '%s'", capturedRequest.URL.Scheme)
+	}
+}
+
+func TestTrustedProxy_SelectiveHeaders(t *testing.T) {
+	os.Setenv("TRUSTED_PROXIES", "127.0.0.1")
+	os.Setenv("TRUST_PROXY_HEADERS", "proto") // Only trust proto, not host
+	defer func() {
+		os.Unsetenv("TRUSTED_PROXIES")
+		os.Unsetenv("TRUST_PROXY_HEADERS")
+	}()
+
+	m := &Middleware{}
+	var capturedRequest *http.Request
+
+	handler := m.TrustedProxy(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		capturedRequest = r
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	req := httptest.NewRequest("GET", "http://localhost/test", nil)
+	req.RemoteAddr = "127.0.0.1:12345"
+	req.Header.Set("X-Forwarded-Proto", "https")
+	req.Header.Set("X-Forwarded-Host", "example.com")
+
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+
+	// Proto should be set
+	if capturedRequest.URL.Scheme != "https" {
+		t.Errorf("Expected scheme 'https', got '%s'", capturedRequest.URL.Scheme)
+	}
+
+	// Host should NOT be set (not in trusted headers)
+	if capturedRequest.Host == "example.com" {
+		t.Error("Expected host to not be set when not in trusted headers")
+	}
+}
+
+func TestTrustedProxy_NoConfiguration(t *testing.T) {
+	// No environment variables set
+	m := &Middleware{}
+	var capturedRequest *http.Request
+
+	handler := m.TrustedProxy(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		capturedRequest = r
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	req := httptest.NewRequest("GET", "http://localhost/test", nil)
+	req.RemoteAddr = "127.0.0.1:12345"
+	req.Header.Set("X-Forwarded-Proto", "https")
+
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+
+	// Should not trust any headers when no proxies configured
+	if capturedRequest.URL.Scheme == "https" {
+		t.Error("Expected scheme to not be set when no proxies configured")
+	}
+}
+
+func TestTrustedProxy_MultipleProxies(t *testing.T) {
+	os.Setenv("TRUSTED_PROXIES", "127.0.0.1,10.0.0.1")
+	os.Setenv("TRUST_PROXY_HEADERS", "proto")
+	defer func() {
+		os.Unsetenv("TRUSTED_PROXIES")
+		os.Unsetenv("TRUST_PROXY_HEADERS")
+	}()
+
+	m := &Middleware{}
+
+	testCases := []struct {
+		name        string
+		remoteAddr  string
+		shouldTrust bool
+	}{
+		{"first proxy", "127.0.0.1:12345", true},
+		{"second proxy", "10.0.0.1:12345", true},
+		{"untrusted IP", "192.168.1.1:12345", false},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			var capturedRequest *http.Request
+
+			handler := m.TrustedProxy(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				capturedRequest = r
+				w.WriteHeader(http.StatusOK)
+			}))
+
+			req := httptest.NewRequest("GET", "http://localhost/test", nil)
+			req.RemoteAddr = tc.remoteAddr
+			req.Header.Set("X-Forwarded-Proto", "https")
+
+			w := httptest.NewRecorder()
+			handler.ServeHTTP(w, req)
+
+			if tc.shouldTrust {
+				if capturedRequest.URL.Scheme != "https" {
+					t.Errorf("Expected scheme 'https' from trusted proxy %s", tc.remoteAddr)
+				}
+			} else {
+				if capturedRequest.URL.Scheme == "https" {
+					t.Errorf("Expected scheme to not be set from untrusted proxy %s", tc.remoteAddr)
+				}
+			}
+		})
+	}
+}
+
+func TestParseTrustedProxies(t *testing.T) {
+	testCases := []struct {
+		name     string
+		input    string
+		expected int
+	}{
+		{"empty string", "", 0},
+		{"single IP", "127.0.0.1", 1},
+		{"multiple IPs", "127.0.0.1,192.168.1.1", 2},
+		{"CIDR range", "192.168.1.0/24", 1},
+		{"mixed", "127.0.0.1,192.168.1.0/24,10.0.0.1", 3},
+		{"with spaces", "127.0.0.1, 192.168.1.1 , 10.0.0.1", 3},
+		{"invalid IP", "invalid-ip", 0},
+		{"IPv6", "::1,fe80::/10", 2},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			networks := parseTrustedProxies(tc.input)
+			if len(networks) != tc.expected {
+				t.Errorf("Expected %d networks, got %d", tc.expected, len(networks))
+			}
+		})
+	}
+}
+
+func TestParseTrustedHeaders(t *testing.T) {
+	testCases := []struct {
+		name     string
+		input    string
+		expected []string
+	}{
+		{"empty uses defaults", "", []string{"proto", "host"}},
+		{"single header", "proto", []string{"proto"}},
+		{"multiple headers", "proto,host", []string{"proto", "host"}},
+		{"with spaces", "proto, host , for", []string{"proto", "host", "for"}},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			headers := parseTrustedHeaders(tc.input)
+			if len(headers) != len(tc.expected) {
+				t.Errorf("Expected %d headers, got %d", len(tc.expected), len(headers))
+				return
+			}
+			for i, h := range headers {
+				if h != tc.expected[i] {
+					t.Errorf("Expected header %s at index %d, got %s", tc.expected[i], i, h)
+				}
+			}
+		})
+	}
+}
+
+func TestGetClientIP(t *testing.T) {
+	testCases := []struct {
+		name       string
+		remoteAddr string
+		headers    map[string]string
+		expected   string
+	}{
+		{
+			name:       "X-Real-IP priority",
+			remoteAddr: "192.168.1.1:12345",
+			headers: map[string]string{
+				"X-Real-IP":       "203.0.113.1",
+				"X-Forwarded-For": "203.0.113.2",
+			},
+			expected: "203.0.113.1",
+		},
+		{
+			name:       "X-Forwarded-For fallback",
+			remoteAddr: "192.168.1.1:12345",
+			headers: map[string]string{
+				"X-Forwarded-For": "203.0.113.1, 192.168.1.1",
+			},
+			expected: "203.0.113.1",
+		},
+		{
+			name:       "RemoteAddr fallback",
+			remoteAddr: "203.0.113.1:12345",
+			headers:    map[string]string{},
+			expected:   "203.0.113.1",
+		},
+		{
+			name:       "IPv6",
+			remoteAddr: "[::1]:12345",
+			headers:    map[string]string{},
+			expected:   "::1",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			req := httptest.NewRequest("GET", "/", nil)
+			req.RemoteAddr = tc.remoteAddr
+
+			for k, v := range tc.headers {
+				req.Header.Set(k, v)
+			}
+
+			result := getClientIP(req)
+			if result != tc.expected {
+				t.Errorf("Expected %s, got %s", tc.expected, result)
+			}
+		})
+	}
+}
+
+func TestIsTrustedProxy(t *testing.T) {
+	networks := parseTrustedProxies("127.0.0.1,192.168.1.0/24")
+
+	testCases := []struct {
+		name     string
+		ip       string
+		expected bool
+	}{
+		{"localhost trusted", "127.0.0.1", true},
+		{"within CIDR", "192.168.1.50", true},
+		{"outside CIDR", "192.168.2.50", false},
+		{"invalid IP", "not-an-ip", false},
+		{"different network", "10.0.0.1", false},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			result := isTrustedProxy(tc.ip, networks)
+			if result != tc.expected {
+				t.Errorf("Expected %t for IP %s, got %t", tc.expected, tc.ip, result)
+			}
+		})
+	}
+}
+
+func TestIsTrustedProxy_EmptyList(t *testing.T) {
+	result := isTrustedProxy("127.0.0.1", []*net.IPNet{})
+	if result {
+		t.Error("Expected false when no proxies are trusted")
+	}
+}


### PR DESCRIPTION
# 🛡️ Add TrustedProxy Middleware to Skeleton App

## 🎯 Overview
This PR adds production-ready `TrustedProxy` middleware to the skeleton app, enabling secure header processing when deployed behind reverse proxies like Nginx, Cloudflare, or AWS ALB.

## 🔐 Security Problem This Solves
Without proper proxy configuration, applications are vulnerable to header spoofing attacks. Any client could send malicious headers like:
```
X-Forwarded-Proto: https
X-Forwarded-Host: malicious.com
```

This middleware implements a **trust-based security model** that only processes forwarded headers from explicitly configured proxy IPs.

## ✨ What's New

### Middleware Features
- 🎯 **IP-based trust validation** - Only trusts headers from configured proxy IPs/CIDRs
- 🔒 **Secure by default** - No headers trusted unless explicitly configured
- ⚙️ **Granular header control** - Choose which headers to trust (proto, host, port, for)
- 🌐 **IPv4/IPv6 support** - Handles both single IPs and CIDR ranges
- 🐳 **Docker-friendly** - Works seamlessly with containerized deployments

### Configuration
Two environment variables control the behavior:

```bash
TRUSTED_PROXIES="127.0.0.1,192.168.1.0/24"  # Trusted proxy IPs/CIDRs
TRUST_PROXY_HEADERS="proto,host"             # Which headers to trust
```

## 📋 Use Cases

### Single Server Setup
```bash
# nginx and app on same machine
TRUSTED_PROXIES="127.0.0.1"
```

### Docker/Container Setup
```bash
# Trust Docker network
TRUSTED_PROXIES="172.17.0.0/16"
```

### Multiple Proxy Tiers
```bash
# Load balancer + nginx
TRUSTED_PROXIES="10.0.1.0/24,192.168.1.0/24"
```

## 🚀 Migration Path

For existing apps, this is **opt-in**:
1. No changes needed if not using proxies
2. Add environment variables when deploying behind a proxy
3. Safe defaults prevent accidental misconfiguration

## 🔍 Code Quality
- Zero external dependencies
- Follows Go best practices
- Comprehensive error handling
- Performance optimized (parses config once at startup)

## 💡 Why This Matters

Production deployments almost always sit behind proxies for:
- SSL termination
- Load balancing  
- CDN integration
- DDoS protection

This middleware makes it **safe and easy** to handle these scenarios correctly.