### PR TITLE
Version bump

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,8 @@
 module myapp
 
-go 1.23.0
+go 1.24.0
 
-toolchain go1.23.4
+toolchain go1.24.4
 
 require (
 	github.com/cidekar/adele-framework v1.0.3


### PR DESCRIPTION
This is a small PR to keep the skeleton application in parity with the latest changes to Go in the Adele Framework. We are moving Go to 1.24 and the Toolchain to 1.24.4. This is a requirement of https://github.com/Cidekar/adele-framework/pull/29 where a fix was committed for [CVE-2025-58181](https://github.com/advisories/GHSA-j5w8-q4qc-rx2x) xcrypto. This change required a version bump go, toolchain, and xcrypto@latest.